### PR TITLE
Fixed issue with undefined response bodies

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -52,12 +52,11 @@ class PhpUnitStyleReporter {
             this.writeRed('F');
             const msg = this.currItem.failedAssertions.join(", ");
             const details = `${this.currItem.response.code}, reason: ${this.currItem.response.reason()}`;
-            let body;
-            try { 
-                body = JSON.parse(this.currItem.response.body);
-            } catch (e) { 
-                body = this.currItem.response.body;
-            }
+            let body = this.currItem.response.stream.toString(); // response.stream is a buffer
+            try {
+                body = JSON.parse(body);
+            } catch (e) {}
+
             let failure = new Object();
             failure.item = this.currItem;
             failure.msg = msg;


### PR DESCRIPTION
Related to https://github.com/postmanlabs/newman/pull/1011

* In Newman versions < `v3.6.0`, the property `item.response.body` would be provided as a string.
* With Newman `v3.6.0` and above, the `body` key has been replaced by `stream`, which is a buffer.